### PR TITLE
Require rspec/core

### DIFF
--- a/lib/rspec/json_expectations.rb
+++ b/lib/rspec/json_expectations.rb
@@ -1,4 +1,4 @@
-require "rspec"
+require "rspec/core"
 require "rspec/json_expectations/version"
 require "rspec/json_expectations/json_traverser"
 require "rspec/json_expectations/failure_presenter"


### PR DESCRIPTION
**Changes json_expectations to require rspec/core instead of rspec.**

This allows json_expectations to be used with rspec-rails without explicity requiring the rspec gem in the Gemfile.

This is similar to this shoulda-matchers issue which was solved in the same way: https://github.com/thoughtbot/shoulda-matchers/issues/248

The recommended way to use [rspec-rails](https://github.com/rspec/rspec-rails) is to put `gem 'rspec-rails'` in the Gemfile.  This pulls in the `rspec-core` gem as a dependency but not the `rspec` gem.  This means json_expecations will fail to find `rspec` in the require path.  As the rspec gem is just a "meta gem" which includes `rspec-core` as a dependency, I've changed the json_expectations to require rspec/core instead.