### PR TITLE
Add UnorderedArray matcher

### DIFF
--- a/features/rspec/json_expectations/unordered_array_support.feature
+++ b/features/rspec/json_expectations/unordered_array_support.feature
@@ -1,0 +1,200 @@
+Feature: Unordered array matching support for include_json matcher
+
+  As a developer extensively testing my APIs
+  I want to be able to match json parts with array
+  And I don't want to be explicit about the order of the elements
+
+  Background:
+    Given a file "spec/spec_helper.rb" with:
+          """ruby
+          require "rspec/json_expectations"
+
+          RSpec.configure do |c|
+            c.include RSpec::JsonExpectations::Matchers
+          end
+          """
+      And a local "JSON_WITH_ARRAY" with:
+          """json
+          {
+            "per_page": 3,
+            "count": 17,
+            "page": 2,
+            "page_count": 6,
+            "results": [
+              {
+                "id": 25,
+                "email": "john.smith@example.com",
+                "badges": ["first flight", "day & night"],
+                "name": "John"
+              },
+              {
+                "id": 26,
+                "email": "john.smith@example.com",
+                "badges": ["first flight"],
+                "name": "John"
+              },
+              {
+                "id": 27,
+                "email": "john.smith@example.com",
+                "badges": ["day & night"],
+                "name": "John"
+              }
+            ]
+          }
+          """
+      And a local "JSON_WITH_ROOT_ARRAY" with:
+          """json
+          [
+            "first flight",
+            "day & night"
+          ]
+          """
+
+  Scenario: Expecting json string to fully include json with arrays
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_json(
+                results: UnorderedArray(
+                  { id: 25, badges: ["first flight", "day & night"] },
+                  { id: 26, badges: ["first flight"] },
+                  { id: 27, badges: ["day & night"] }
+                )
+              )
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+          1 example, 0 failures
+          """
+
+  Scenario: Expecting json string to fully include json with arrays with different order
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_json(
+                results: UnorderedArray(
+                  { id: 26, badges: ["first flight"] },
+                  { id: 27, badges: ["day & night"] },
+                  { id: 25, badges: ["first flight", "day & night"] }
+                )
+              )
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+          1 example, 0 failures
+          """
+
+  Scenario: Expecting json string to fully include json with wrong values
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_json(
+                results: UnorderedArray(
+                  { id: 26, badges: ["first flight"] },
+                  { id: 35, badges: ["unknown", "badge"] },
+                  { id: 27, badges: ["day & night"] },
+                  { id: 25, badges: ["first flight", "day & night"] }
+                )
+              )
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+                           json atom at path "results/1" is missing
+          """
+      And I see:
+          """
+                             expected: {:id=>35, :badges=>["unknown", "badge"]}
+                                  got: nil
+          """
+
+  Scenario: Expecting json string with array at root to fully include json with arrays
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ROOT_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_json(
+                UnorderedArray( "first flight", "day & night" )
+              )
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+          1 example, 0 failures
+          """
+
+  Scenario: Expecting json string with array at root to fully include json with arrays with different order
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ROOT_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_json(
+                UnorderedArray( "day & night", "first flight" )
+              )
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+          1 example, 0 failures
+          """
+
+  Scenario: Expecting json string with array at root to fully include json with wrong values
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ROOT_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_json(
+                UnorderedArray( "day & night", "unknown", "first flight" )
+              )
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+                           json atom at path "1" is missing
+          """
+      And I see:
+          """
+                             expected: "unknown"
+                                  got: nil
+          """

--- a/lib/rspec/json_expectations/failure_presenter.rb
+++ b/lib/rspec/json_expectations/failure_presenter.rb
@@ -14,7 +14,8 @@ module RSpec
           [
             render_no_key(path, error, negate),
             render_not_eq(path, error, negate),
-            render_not_match(path, error, negate)
+            render_not_match(path, error, negate),
+            render_missing(path, error, negate)
           ].select { |e| e }.first
         end
 
@@ -42,12 +43,31 @@ module RSpec
           } if error_is_not_match?(error)
         end
 
+        def render_missing(path, error, negate=false)
+          return unless error_is_missing?(error)
+
+          prefix = "#{path}/" if path && !path.empty?
+
+          items = error[:missing].map do |item|
+            %{
+          json atom at path "#{prefix}#{item[:index]}" is missing
+
+            expected: #{item[:item].inspect}
+                 got: nil
+            }
+          end.join("\n")
+        end
+
         def error_is_not_eq?(error)
           error.is_a?(Hash) && error.has_key?(:expected) && !error[:expected].is_a?(Regexp)
         end
 
         def error_is_not_match?(error)
           error.is_a?(Hash) && error.has_key?(:expected) && error[:expected].is_a?(Regexp)
+        end
+
+        def error_is_missing?(error)
+          error.is_a?(Hash) && error.has_key?(:missing)
         end
       end
     end

--- a/lib/rspec/json_expectations/matchers.rb
+++ b/lib/rspec/json_expectations/matchers.rb
@@ -36,7 +36,9 @@ RSpec::Matchers.define :include_json do |expected|
   end
 
   def traverse(expected, actual, negate=false)
-    unless expected.is_a?(Hash) || expected.is_a?(Array)
+    unless expected.is_a?(Hash) ||
+        expected.is_a?(Array) ||
+        expected.is_a?(::RSpec::JsonExpectations::Matchers::UnorderedArrayMatcher)
       raise ArgumentError,
         "Expected value must be a json for include_json matcher"
     end
@@ -50,5 +52,48 @@ RSpec::Matchers.define :include_json do |expected|
       representation,
       negate
     )
+  end
+end
+
+module RSpec
+  module JsonExpectations
+    module Matchers
+      class UnorderedArrayMatcher
+        attr_reader :array
+        def initialize(array)
+          @array = array
+        end
+
+        def match(errors, actual, prefix)
+          missing_items = []
+          errors[prefix.join("/")] = { missing: missing_items }
+
+          all? do |expected_item, index|
+            match_one(missing_items, expected_item, index, actual)
+          end
+        end
+
+        def match_one(missing, item, index, actual)
+          check_for_missing(missing, item, index,
+            actual.any? do |actual_item|
+              JsonTraverser.traverse({}, item, actual_item, false)
+            end
+          )
+        end
+
+        def check_for_missing(missing, item, index, ok)
+          missing << { item: item, index: index } unless ok
+          ok
+        end
+
+        def all?(&blk)
+          array.each_with_index.all?(&blk)
+        end
+      end
+
+      def UnorderedArray(*array)
+        UnorderedArrayMatcher.new(array)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #7 

This introduces a new special syntax for defining unordered array expectations:

```ruby
expect(response).to include_json(
  users: UnorderedArray(
    { .. },
    { .. },
    ......
  )
)
```

This matcher succeeds, if all expected elements can be found in the actual array in any order. It fails if at least one element can not be found. Elements are matched the same way `include_json` matcher works, so it is possible to have regex and even another `UnorderedArray` inside of element expectations.

/cc @benoittgt