### PR TITLE
Implement include_unordered_json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/features/rspec/json_expectations/unordered_array_support.feature
+++ b/features/rspec/json_expectations/unordered_array_support.feature
@@ -152,6 +152,25 @@ Feature: Unordered array matching support for include_json matcher
           1 example, 0 failures
           """
 
+  Scenario: Expecting json string with array at root to fully include json with arrays using alternative syntax
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ROOT_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_unordered_json ["first flight", "day & night"]
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+          1 example, 0 failures
+          """
+
   Scenario: Expecting json string with array at root to fully include json with arrays with different order
     Given a file "spec/nested_example_spec.rb" with:
           """ruby
@@ -173,6 +192,25 @@ Feature: Unordered array matching support for include_json matcher
           1 example, 0 failures
           """
 
+  Scenario: Expecting json string with array at root to fully include json with arrays with different order using alternative syntax
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ROOT_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_unordered_json ["day & night", "first flight"]
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+          1 example, 0 failures
+          """
+
   Scenario: Expecting json string with array at root to fully include json with wrong values
     Given a file "spec/nested_example_spec.rb" with:
           """ruby
@@ -185,6 +223,30 @@ Feature: Unordered array matching support for include_json matcher
               expect(subject).to include_json(
                 UnorderedArray( "day & night", "unknown", "first flight" )
               )
+            end
+          end
+          """
+     When I run "rspec spec/nested_example_spec.rb"
+     Then I see:
+          """
+                           json atom at path "1" is missing
+          """
+      And I see:
+          """
+                             expected: "unknown"
+                                  got: nil
+          """
+
+  Scenario: Expecting json string with array at root to fully include json with wrong values using alternative syntax
+    Given a file "spec/nested_example_spec.rb" with:
+          """ruby
+          require "spec_helper"
+
+          RSpec.describe "A json response" do
+            subject { '%{JSON_WITH_ROOT_ARRAY}' }
+
+            it "has basic info about user" do
+              expect(subject).to include_unordered_json ["day & night", "unknown", "first flight"]
             end
           end
           """

--- a/lib/rspec/json_expectations.rb
+++ b/lib/rspec/json_expectations.rb
@@ -1,7 +1,5 @@
 require "rspec/core"
 require "rspec/json_expectations/matcher_factory"
-require "rspec/json_expectations/base_matcher"
-require "rspec/json_expectations/include_json_matcher"
 require "rspec/json_expectations/version"
 require "rspec/json_expectations/json_traverser"
 require "rspec/json_expectations/failure_presenter"

--- a/lib/rspec/json_expectations.rb
+++ b/lib/rspec/json_expectations.rb
@@ -1,4 +1,7 @@
 require "rspec/core"
+require "rspec/json_expectations/matcher_factory"
+require "rspec/json_expectations/base_matcher"
+require "rspec/json_expectations/include_json_matcher"
 require "rspec/json_expectations/version"
 require "rspec/json_expectations/json_traverser"
 require "rspec/json_expectations/failure_presenter"

--- a/lib/rspec/json_expectations/matcher_factory.rb
+++ b/lib/rspec/json_expectations/matcher_factory.rb
@@ -1,0 +1,50 @@
+module RSpec
+  module JsonExpectations
+    class MatcherFactory
+      def initialize(matcher_name)
+        @matcher_name = matcher_name
+      end
+
+      def define_matcher(&block)
+        RSpec::Matchers.define(@matcher_name) do |expected|
+          yield
+
+          # RSpec 2 vs 3
+          if respond_to?(:failure_message)
+            match do |actual|
+              traverse(expected, actual, false)
+            end
+
+            match_when_negated do |actual|
+              traverse(expected, actual, true)
+            end
+
+            failure_message do |actual|
+              RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+            end
+
+            failure_message_when_negated do |actual|
+              RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+            end
+          else
+            match_for_should do |actual|
+              traverse(expected, actual, false)
+            end
+
+            match_for_should_not do |actual|
+              traverse(expected, actual, true)
+            end
+
+            failure_message_for_should do |actual|
+              RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+            end
+
+            failure_message_for_should_not do |actual|
+              RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/json_expectations/matchers.rb
+++ b/lib/rspec/json_expectations/matchers.rb
@@ -55,6 +55,64 @@ RSpec::Matchers.define :include_json do |expected|
   end
 end
 
+RSpec::Matchers.define :include_unordered_json do |expected|
+
+  # RSpec 2 vs 3
+  if respond_to?(:failure_message)
+    match do |actual|
+      traverse(expected, actual, false)
+    end
+
+    match_when_negated do |actual|
+      traverse(expected, actual, true)
+    end
+
+    failure_message do |actual|
+       RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+    end
+
+    failure_message_when_negated do |actual|
+       RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+    end
+  else
+    match_for_should do |actual|
+      traverse(expected, actual, false)
+    end
+
+    match_for_should_not do |actual|
+      traverse(expected, actual, true)
+    end
+
+    failure_message_for_should do |actual|
+      RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+    end
+
+    failure_message_for_should_not do |actual|
+      RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
+    end
+  end
+
+  def traverse(expected, actual, negate=false)
+    unless expected.is_a?(Array)
+      raise ArgumentError,
+        "Expected value must be a array for include_unordered_json matcher"
+    end
+
+    actual_json = actual
+    actual_json = JSON.parse(actual) if String === actual
+
+    expected_wrapped_in_unordered_array = \
+      RSpec::JsonExpectations::Matchers::UnorderedArrayMatcher.new(expected)
+
+    RSpec::JsonExpectations::JsonTraverser.traverse(
+      @include_json_errors = { _negate: negate },
+      expected_wrapped_in_unordered_array,
+      actual_json,
+      negate
+    )
+  end
+end
+
 module RSpec
   module JsonExpectations
     module Matchers

--- a/lib/rspec/json_expectations/matchers.rb
+++ b/lib/rspec/json_expectations/matchers.rb
@@ -1,40 +1,4 @@
-RSpec::Matchers.define :include_json do |expected|
-
-  # RSpec 2 vs 3
-  if respond_to?(:failure_message)
-    match do |actual|
-      traverse(expected, actual, false)
-    end
-
-    match_when_negated do |actual|
-      traverse(expected, actual, true)
-    end
-
-    failure_message do |actual|
-       RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-
-    failure_message_when_negated do |actual|
-       RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-  else
-    match_for_should do |actual|
-      traverse(expected, actual, false)
-    end
-
-    match_for_should_not do |actual|
-      traverse(expected, actual, true)
-    end
-
-    failure_message_for_should do |actual|
-      RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-
-    failure_message_for_should_not do |actual|
-      RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-  end
-
+RSpec::JsonExpectations::MatcherFactory.new(:include_json).define_matcher do
   def traverse(expected, actual, negate=false)
     unless expected.is_a?(Hash) ||
         expected.is_a?(Array) ||
@@ -55,43 +19,7 @@ RSpec::Matchers.define :include_json do |expected|
   end
 end
 
-RSpec::Matchers.define :include_unordered_json do |expected|
-
-  # RSpec 2 vs 3
-  if respond_to?(:failure_message)
-    match do |actual|
-      traverse(expected, actual, false)
-    end
-
-    match_when_negated do |actual|
-      traverse(expected, actual, true)
-    end
-
-    failure_message do |actual|
-       RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-
-    failure_message_when_negated do |actual|
-       RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-  else
-    match_for_should do |actual|
-      traverse(expected, actual, false)
-    end
-
-    match_for_should_not do |actual|
-      traverse(expected, actual, true)
-    end
-
-    failure_message_for_should do |actual|
-      RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-
-    failure_message_for_should_not do |actual|
-      RSpec::JsonExpectations::FailurePresenter.render(@include_json_errors)
-    end
-  end
-
+RSpec::JsonExpectations::MatcherFactory.new(:include_unordered_json).define_matcher do
   def traverse(expected, actual, negate=false)
     unless expected.is_a?(Array)
       raise ArgumentError,


### PR DESCRIPTION
This is intended as a replacement for `include_json UnorderedArray(...)`. Personally I think this is a slight improvement in the case where expected is an array; curious to know what you think of it.

Not sure if it's a good idea to automagically travel `expected`, and convert any arrays to `UnorderedArray`s.

E.g, transform this

```
{
  results: {
    foo: bar,
    foobar: ["one foo", "two foo"]
  },
  baz: ["qux"]
}
```

into this:
```
{
  results: {
    foo: bar,
    foobar: UnorderedArray.new(["one foo", "two foo"])
  },
  baz: UnorderedArray.new(["qux"])
}
```

Moreover, I would like to DRY this up. I don't know a lot about writing RSpec matchers, but (by the looks of it)[http://makandracards.com/makandra/662-write-custom-rspec-matchers], if I were to make a matcher class, it looks like users would have to include this, which is a bit of a shame. Could also use some `instance_eval` magic here, but not sure if that's such a great idea.

Details aside, I look forward to hearing your thoughts on this suggestion. Let me know what you think!