### PR TITLE
Add missing require for Forwardable

### DIFF
--- a/lib/rspec/json_expectations/matchers.rb
+++ b/lib/rspec/json_expectations/matchers.rb
@@ -1,3 +1,5 @@
+require "forwardable"
+
 RSpec::JsonExpectations::MatcherFactory.new(:include_json).define_matcher do
   def traverse(expected, actual, negate=false)
     unless expected.is_a?(Hash) ||


### PR DESCRIPTION
The lack of this require is masked when running the features with
bundler, since bundler itself requires forwardable, but there is no
guarantee that this will always be the case when this code is used.