### PR TITLE
Fix error with rspec-rails gem on version 3.5.2

### DIFF
--- a/lib/rspec/json_expectations.rb
+++ b/lib/rspec/json_expectations.rb
@@ -1,4 +1,5 @@
 require "rspec/core"
+require "rspec/expectations"
 require "rspec/json_expectations/matcher_factory"
 require "rspec/json_expectations/version"
 require "rspec/json_expectations/json_traverser"


### PR DESCRIPTION
Fix the error with rspec-rails-3.5.2 and rspec-3.5

```

/home/user/.rvm/gems/ruby-2.3.3@mygemset/gems/rspec-json_expectations-2.1.0/lib/rspec/json_expectations/matcher_factory.rb:9:in `define_matcher': undefined method `define' for RSpec::Matchers:Module (NoMethodError)
Did you mean?  define_method
               refine

```