### PR TITLE
use bundler ~> 1.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ gemfile:
   - gemfiles/rspec-3
 
 before_install:
-  - gem install bundler
+  - gem install bundler -v "~> 1.0"
 
 script: bundle exec cucumber


### PR DESCRIPTION
The purpose of this PR is to allow builds to pass on Travis, as simply as possible. There is currently a build error for `master`:
https://travis-ci.org/waterlink/rspec-json_expectations/jobs/502880454. 
```
0.48s$ gem install bundler
Fetching: bundler-2.0.1.gem (100%)
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.3. Try installing it with `gem install bundler -v 1.17.3`
	bundler requires Ruby version >= 2.3.0. The current ruby version is 2.1.0.
```
`bundler 2.x` can be used once https://github.com/waterlink/rspec-json_expectations/pull/26 is merged, as `bundler 2` does not require `forwardable` itself.