### PR TITLE
Define traverse methods in proper context

### DIFF
--- a/lib/rspec/json_expectations/matcher_factory.rb
+++ b/lib/rspec/json_expectations/matcher_factory.rb
@@ -7,7 +7,7 @@ module RSpec
 
       def define_matcher(&block)
         RSpec::Matchers.define(@matcher_name) do |expected|
-          yield
+          self.module_eval(&block)
 
           match do |actual|
             traverse(expected, actual, false)


### PR DESCRIPTION
In the same spirit as how `RSpec::Matchers::define` evaluates given blocks in the context of a class/module, evaluate blocks given to `RSpec::JsonExpectations::MatcherFactory#define_matcher` in the same manner. Any methods defined in the given block will be defined as instance methods on the new `Matcher` rather than in a main/global context.

Partially addresses #28 (warnings about `#traverse` getting redefined).