### PR TITLE
fix: remove explicit dependency to rspec itself

### DIFF
--- a/lib/rspec/json_expectations.rb
+++ b/lib/rspec/json_expectations.rb
@@ -1,4 +1,3 @@
-require "rspec/core"
 require "rspec/expectations"
 require "rspec/json_expectations/matcher_factory"
 require "rspec/json_expectations/version"


### PR DESCRIPTION
- [x] ! remove explicit dependency to rspec itself